### PR TITLE
🔐 Allow private repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ Works best if you view with markdown plugin or markdown viewer because the conte
 
 npm: [npmjs.com/package/get-issues](https://www.npmjs.com/package/get-issues)
 
-## work in progress
 
-* this project is still new, so private repos won't work currently
-* `get-issues` uses the https git remote url to find issues, so if your remote origin uses ssh, it won't work, yet!
+✅ works with public github repos
+✅ works with private repos with Github's access tokens
+❎ will soon work with github's 2-factor-authentication
+✅ works with ssh or https remote github URLs
+✅ works great when used in conjunction with `npm scripts`, using a `post-install` script

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "commander": "^2.9.0",
     "figlet": "^1.1.1",
     "git-tools": "^0.2.1",
+    "github": "^0.2.4",
+    "inquirer": "^0.11.0",
     "request": "^2.65.0",
     "slug": "^0.9.1",
     "ssh-url": "^0.1.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-issues",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "description": "cli that downloads all github issues from project for offline use",
   "scripts": {
     "pretest": "standard",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-issues",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "cli that downloads all github issues from project for offline use",
   "scripts": {
     "pretest": "standard",

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,13 @@ require('./addToGitignore.js')
 require('colors')
 
 // set options for github api requests
+var options = {
+  headers: {
+    'User-Agent': 'request'
+  }
+}
+
+// set options for github api requests
 var callURL = function (url, cb) {
   var options = {
     url: url,
@@ -56,7 +63,7 @@ async.waterfall([
 
   // get remote github url for use with api
   function getGithubURL (init, cb) {
-    var repo = new Repo('../bear-safety/')
+    var repo = new Repo(__dirname)
     repo.remotes(function ( error, remotes) {
       if (error) {
         cb(error, null)

--- a/src/index.js
+++ b/src/index.js
@@ -5,13 +5,21 @@
 var async = require('async')
 var Repo = require('git-tools')
 var request = require('request')
-var fs = require('fs')
+var fs = require('fs-extra')
 var figlet = require('figlet')
 var slug = require('slug')
 var util = require('util')
 var url = require('url')
 var sshURL = require('ssh-url')
 var options = require('./options')
+var inquirer = require('inquirer')
+var github = new (require('github'))({version: '3.0.0'})
+var os = require('os')
+var path = require('path')
+
+// attempt at a platform agnostic place to store auth tokens
+var configDir = path.resolve(os.homedir(), '.config' , 'get-issues')
+var configFile = path.resolve(configDir, 'setup.json')
 
 require('./addToGitignore.js')
 require('colors')
@@ -40,9 +48,10 @@ var callURL = function (url, cb) {
   request(options, callback)
 }
 
+
 async.waterfall([
 
-  // check if gh-folder needs to be created
+  // check if /issues folder needs to be created
   function init (cb) {
     if (!fs.existsSync('./issues')) {
       fs.mkdirSync('./issues')
@@ -53,7 +62,7 @@ async.waterfall([
 
   // get remote github url for use with api
   function getGithubURL (init, cb) {
-    var repo = new Repo('./')
+    var repo = new Repo(__dirname)
     repo.remotes(function ( error, remotes) {
       if (error) {
         cb(error, null)
@@ -65,6 +74,7 @@ async.waterfall([
 
   function makeApiUrl (remoteURL, cb) {
     var parsedURL = url.parse(remoteURL)
+    var currentRepoInfo = {}
 
     // handle ssh remote URL
     if (!parsedURL.protocol) {
@@ -74,6 +84,8 @@ async.waterfall([
         host: util.format('api.%s', parsedURL.hostname),
         pathname: `repos${parsedURL.pathname.split('.')[0]}/issues`
       })
+      currentRepoInfo.username = parsedURL.pathname.split('/')[1]
+      currentRepoInfo.repo = path.basename(remoteURL, '.git')
     } else {
       // handle https remote URL
       var splitURL = parsedURL.pathname.split('/')
@@ -82,17 +94,23 @@ async.waterfall([
         host: util.format('api.%s', parsedURL.host),
         pathname: `/repos/${splitURL[1]}/${splitURL[2].split('.')[0]}/issues`
       })
+      currentRepoInfo.username = parsedURL.pathname.split('/')[1]
+      currentRepoInfo.repo = path.basename(remoteURL, '.git')
     }
 
-    cb(null, finalURL)
+    cb(null, finalURL, currentRepoInfo)
   },
 
   // make request to remote repo's issue page
-  function getIssues (finalURL, cb) {
+  function getIssues (finalURL, currentRepoInfo, cb) {
+
     options.url = finalURL
     function callback (error, response, body) {
       if (error) {
         cb(error, null)
+      }
+      if (!error && response.statusCode !== 200 ) {
+        cb(error, 'invalid repo', currentRepoInfo)
       }
       if (!error && response.statusCode === 200) {
         var info = JSON.parse(body)
@@ -102,20 +120,112 @@ async.waterfall([
             filterOutPR.push(issue)
           }
         })
-        cb(null, filterOutPR)
+        cb(null, filterOutPR, currentRepoInfo)
       }
     }
 
     request(options, callback)
   },
 
+  // if repo is private, checks for github auth token
+  function checkIfPrivateRepo (filterOutPR, currentRepoInfo, cb) {
+
+    if (filterOutPR === 'invalid repo') {
+      // let's check if this token already exits
+      fs.readJSON(configFile, function(err, obj) {
+          if (err) {
+            var tokenCheck = true
+            // no token found
+            cb(null, filterOutPR, tokenCheck, currentRepoInfo)
+          } else {
+            var tokenCheck = obj.token
+            // found token that exits already
+            cb(null, filterOutPR, tokenCheck, currentRepoInfo)
+          }
+        })
+    } else if (filterOutPR) {
+      var tokenCheck = false
+      cb(null, filterOutPR, tokenCheck, currentRepoInfo)
+    }
+  },
+
+  // if token is need and doesn't exists create it
+  function getTokenIfNeeded(filterOutPR, tokenCheck, currentRepoInfo, cb) {
+    var tokenFinal
+
+    // if tokenCheck is true, need to get token prompts user
+    if (tokenCheck === true){
+      // it's a private repo
+      var questions = [
+        {
+          type: "input",
+          name: "token",
+          message: "https://github.com/settings/tokens/new?scopes=repo&description=get%20issues%20CLI".red.underline +  "\n\n  This token will be stored locally for future use. \n  Use above link to create a github access token and paste it here: "
+        }
+      ]
+      // get user to past github activity token with "repo" privileges
+      inquirer.prompt( questions, function( answers ) {
+        var tokenFinal = answers.token
+        fs.outputJSON(configFile, {token: tokenFinal}, function(err){
+          if (err) throw err
+          cb(null, tokenFinal, filterOutPR, currentRepoInfo)
+        })
+      })
+    } else if (!tokenCheck) {
+      // not private repo, no auth needed
+      tokenFinal = 'public'
+      cb(null, tokenFinal, filterOutPR, currentRepoInfo)
+    } else {
+      // token already exists, just read it
+      tokenFinal = tokenCheck
+      cb(null, tokenFinal, filterOutPR, currentRepoInfo)
+    }
+
+  },
+
+  function githubAuthIfNeed(tokenFinal, filterOutPR, currentRepoInfo, cb) {
+
+    // skip github auth if public repo
+    if (tokenFinal === 'public') {
+      cb(null, filterOutPR)
+    } else if (tokenFinal) {
+
+      github.authenticate({
+          type: "oauth",
+          token: tokenFinal
+      })
+      github.issues.repoIssues({
+          user: currentRepoInfo.username,
+          repo: currentRepoInfo.repo,
+          state: 'open',
+          per_page: 100
+      }, function(err, res) {
+          if (err) {
+            // bad credentials
+            fs.remove(configFile, function(err){if (err) throw err})
+          } else {
+            // good credentials
+            var filterOutPR = []
+
+            res.forEach(function (issue) {
+              if (!issue.pull_request) {
+                filterOutPR.push(issue)
+              }
+            })
+            cb(null, filterOutPR)
+          }
+      })
+    }
+  },
+
   // create a file for each issue in /issues
   function createIssueFiles (filterOutPR, cb) {
+
     var commentsURL = []
     filterOutPR.forEach(function (issue) {
       // slugify title to get rid of characters that can cause filename problems
       var issueFilename = util.format('issues/%s-%s.md', String(issue.number), slug(issue.title))
-      // template strings use indents, to avoid indents we must forego code readability
+      // template strings use indents, to avoid indents we must forgo code readability
       var finalIssue = `${issue.title}
 Issue filed by: ${issue.user.login}
 ${Date(issue.created_at)}
@@ -205,7 +315,7 @@ ${individualComment.body}
       console.error(err)
       return
     }
-
+    // fancy ouput
     figlet.text('got issues!', {
       horizontalLayout: 'default',
       verticalLayout: 'default'

--- a/src/index.js
+++ b/src/index.js
@@ -25,12 +25,6 @@ require('./addToGitignore.js')
 require('colors')
 
 // set options for github api requests
-var options = {
-  headers: {
-    'User-Agent': 'request'
-  }
-}
-
 var callURL = function (url, cb) {
   var options = {
     url: url,
@@ -62,7 +56,7 @@ async.waterfall([
 
   // get remote github url for use with api
   function getGithubURL (init, cb) {
-    var repo = new Repo(__dirname)
+    var repo = new Repo('../bear-safety/')
     repo.remotes(function ( error, remotes) {
       if (error) {
         cb(error, null)
@@ -160,7 +154,7 @@ async.waterfall([
         {
           type: "input",
           name: "token",
-          message: "https://github.com/settings/tokens/new?scopes=repo&description=get%20issues%20CLI".red.underline +  "\n\n  This token will be stored locally for future use. \n  Use above link to create a github access token and paste it here: "
+          message: "https://github.com/settings/tokens/new?scopes=repo&description=get%20issues%20CLI".red.underline + "\n\n ⎔".magenta + " Click above link to create a Github access token" + "\n\n ⎔".magenta + " Leave \"scope\" options as is, and click \"Generate token\" " + "\n\n ⎔".magenta + " This token will be stored locally and used whenever accessing a private repo" + "\n\n ⎔".magenta + " Paste token here:"
         }
       ]
       // get user to past github activity token with "repo" privileges
@@ -315,7 +309,7 @@ ${individualComment.body}
       console.error(err)
       return
     }
-    // fancy ouput
+    // fancy output
     figlet.text('got issues!', {
       horizontalLayout: 'default',
       verticalLayout: 'default'


### PR DESCRIPTION
Attempting to make the friendliest github authentication flow possible.

* if repo is public doesn't ask for authentication
* if repo is private checks if github access token exits
* if auth token doesn't exists it prompts user to go and generate one
* stores token so don't need to prompt user in future
